### PR TITLE
`import helm` command

### DIFF
--- a/cmd/spresm/import.go
+++ b/cmd/spresm/import.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+
+	"github.com/squaremo/spresm/pkg/eval"
+	"github.com/squaremo/spresm/pkg/spec"
+)
+
+func newImportCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: `import a package from a git repository, chart or image`,
+	}
+	cmd.AddCommand(
+		newImportHelmChartCommand(),
+	)
+	return cmd
+}
+
+func newImportHelmChartCommand() *cobra.Command {
+	flags := &importHelmChartFlags{}
+	cmd := &cobra.Command{
+		Use:   "helm <dir> --chart <chart URL> --version <version>",
+		Short: `import a Helm chart as a package`,
+		RunE:  flags.importHelmChart,
+	}
+	flags.init(cmd)
+	return cmd
+}
+
+type importHelmChartFlags struct {
+	chartURL, version string
+}
+
+func (flags *importHelmChartFlags) init(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&flags.chartURL, "chart", "", "URL for chart, including the repository; e.g., https://charts.fluxcd.io/flux")
+	cmd.Flags().StringVar(&flags.version, "version", "", "version of chart to use")
+}
+
+func (flags *importHelmChartFlags) importHelmChart(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected exactly one argument, the directory in which to put the package files")
+	}
+	dir := args[0]
+	if flags.chartURL == "" || flags.version == "" {
+		return fmt.Errorf("need both chart URL (--chart) and version (--version) flags")
+	}
+
+	// TODO make sure the target directory doesn't exist, or at least
+	// is empty (?)
+	dirstat, err := os.Stat(dir)
+	switch {
+	case os.IsNotExist(err):
+		if err := os.MkdirAll(dir, os.FileMode(0777)); err != nil {
+			return fmt.Errorf("failed to create directory %s for import: %w", dir, err)
+		}
+	case err != nil:
+		return fmt.Errorf("error trying to establish import directory %s: %w", dir, err)
+	case !dirstat.IsDir():
+		return fmt.Errorf("expected %s to be a directory or not exist yet")
+	default:
+		// exists already, and is a directory
+		d, err := os.Open(dir)
+		if err != nil {
+			return fmt.Errorf("error reading contents of %s: %w", dir, err)
+		}
+		contents, err := d.Readdir(0)
+		if err != nil {
+			return fmt.Errorf("error reading contents of %s: %w", dir, err)
+		}
+		if len(contents) > 0 {
+			return fmt.Errorf("directory %s exists but is not empty; cannot import into a directory which already has files", dir)
+		}
+	}
+
+	// create spec file
+	var s spec.Spec
+	s.Init(spec.ChartKind)
+	s.Source = flags.chartURL
+	s.Version = flags.version
+
+	// get the chart
+	chart, err := eval.ProcureChart(flags.chartURL, flags.version)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "chart found %q\n", chart.Name())
+
+	// TODO present the values for editing
+
+	// TODO put the values into the spec
+
+	specPath := filepath.Join(dir, Spresmfile)
+	buf := &bytes.Buffer{}
+	err = yaml.NewEncoder(buf).Encode(s)
+	if err == nil {
+		err = ioutil.WriteFile(specPath, buf.Bytes(), os.FileMode(0600))
+	}
+	if err != nil {
+		return fmt.Errorf("failed to encode and write spec to %s: %w", specPath, err)
+	}
+	fmt.Fprintf(os.Stderr, "spec file written to %s\n", specPath)
+
+	// TODO eval (update, really) the spec, to render the chart into
+	// the directory. This bit will be in common with other import
+	// commands, so stick it in pkg somewhere.
+	resources, err := eval.Eval(s)
+	writer := kio.LocalPackageWriter{PackagePath: dir}
+	if err := writer.Write(resources); err != nil {
+		return fmt.Errorf("problem writing to the directory %s: %w", dir, err)
+	}
+	fmt.Fprintf(os.Stderr, "spec evaluated to %s\n", dir)
+	return nil
+}

--- a/cmd/spresm/main.go
+++ b/cmd/spresm/main.go
@@ -18,13 +18,6 @@ func main() {
 	root.Execute()
 }
 
-func newImportCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "import",
-		Short: `import a package from a git repository, chart or image`,
-	}
-}
-
 func newUpdateCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "update <dir>",

--- a/pkg/eval/chart.go
+++ b/pkg/eval/chart.go
@@ -1,0 +1,58 @@
+package eval
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+func ProcureChart(repoAndChartURL, version string) (*chart.Chart, error) {
+	u, err := url.Parse(repoAndChartURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse chart URL: %w", err)
+	}
+	pathElements := strings.Split(u.Path, "/")
+	if len(pathElements) < 1 {
+		return nil, fmt.Errorf("path of chart URL must include at least one element, naming the chart")
+	}
+	chartName := pathElements[len(pathElements)-1]
+	u.Path = u.Path[:len(u.Path)-len(chartName)]
+
+	// Now we expect the URL to be the Helm repository; do the magic to fetch the index.
+	// TODO: Respect the local cache, rather than downloading every time.
+	certFile, keyFile, caFile := "", "", ""
+	providers := getter.Providers{
+		getter.Provider{
+			Schemes: []string{"http", "https"},
+			New:     getter.NewHTTPGetter,
+		},
+	}
+	// ^ cargo culted from fluxcd/source-controller, I can't find
+	// where this is done in Helm itself.
+
+	downloadUrl, err := repo.FindChartInRepoURL(u.String(), chartName, version, certFile, keyFile, caFile, providers)
+	if err != nil {
+		return nil, fmt.Errorf("could not find chart download URL: %w", err)
+	}
+
+	get, err := providers.ByScheme(u.Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("could not find how to download chart: %w", err)
+	}
+
+	buf, err := get.Get(downloadUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download chart: %w", err)
+	}
+	chart, err := loader.LoadArchive(buf)
+	if err != nil {
+		return nil, fmt.Errorf("could not load downloaded chart archive: %w", err)
+	}
+
+	return chart, nil
+}

--- a/pkg/eval/helm.go
+++ b/pkg/eval/helm.go
@@ -14,12 +14,6 @@ import (
 	"github.com/squaremo/spresm/pkg/spec"
 )
 
-// [DEBUG]
-import (
-	yamlv3 "gopkg.in/yaml.v3"
-	"os"
-)
-
 // evalHelmChart evaluates a spec with the kind "HelmChart".
 func evalHelmChart(s spec.Spec) ([]*yaml.RNode, error) {
 	// The format expected here looks like a regular URL; everything
@@ -37,9 +31,6 @@ func evalHelmChart(s spec.Spec) ([]*yaml.RNode, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not create values for chart templates: %w", err)
 	}
-
-	// [DEBUG]
-	yamlv3.NewEncoder(os.Stderr).Encode(values)
 
 	rendered, err := engine.Render(chart, values)
 	if err != nil {

--- a/pkg/eval/helm.go
+++ b/pkg/eval/helm.go
@@ -2,15 +2,11 @@ package eval
 
 import (
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strings"
 
-	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/engine"
-	"helm.sh/helm/v3/pkg/getter"
-	"helm.sh/helm/v3/pkg/repo"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -29,47 +25,10 @@ func evalHelmChart(s spec.Spec) ([]*yaml.RNode, error) {
 	// The format expected here looks like a regular URL; everything
 	// up to the last path element is taken as the repository URL, and
 	// the last path element is taken as naming the chart.
-	repoAndChartUrl := s.Source
-	u, err := url.Parse(repoAndChartUrl)
+	repoAndChartURL := s.Source
+	chart, err := ProcureChart(repoAndChartURL, s.Version)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse chart URL: %w", err)
-	}
-	pathElements := strings.Split(u.Path, "/")
-	if len(pathElements) < 1 {
-		return nil, fmt.Errorf("path of chart URL must include at least one element, naming the chart")
-	}
-	chartName := pathElements[len(pathElements)-1]
-	u.Path = u.Path[:len(u.Path)-len(chartName)]
-
-	// Now we expect the URL to be the Helm repository; do the magic to fetch the index.
-	// TODO: Respect the local cache, rather than downloading every time.
-	certFile, keyFile, caFile := "", "", ""
-	providers := getter.Providers{
-		getter.Provider{
-			Schemes: []string{"http", "https"},
-			New:     getter.NewHTTPGetter,
-		},
-	}
-	// ^ cargo culted from fluxcd/source-controller, I can't find
-	// where this is done in Helm itself.
-
-	downloadUrl, err := repo.FindChartInRepoURL(u.String(), chartName, s.Version, certFile, keyFile, caFile, providers)
-	if err != nil {
-		return nil, fmt.Errorf("could not find chart download URL: %w", err)
-	}
-
-	get, err := providers.ByScheme(u.Scheme)
-	if err != nil {
-		return nil, fmt.Errorf("could not find how to download chart: %w", err)
-	}
-
-	buf, err := get.Get(downloadUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download chart: %w", err)
-	}
-	chart, err := loader.LoadArchive(buf)
-	if err != nil {
-		return nil, fmt.Errorf("could not load downlaoded chart: %w", err)
+		return nil, err
 	}
 
 	// Finally we have an actual chart.
@@ -88,7 +47,7 @@ func evalHelmChart(s spec.Spec) ([]*yaml.RNode, error) {
 	}
 
 	var result []*yaml.RNode
-	basepath := filepath.Join(chartName, "templates")
+	basepath := filepath.Join(chart.Name(), "templates")
 	for filename, src := range rendered {
 		// probably fine hack: ignore anything that's not YAMLish
 		if !(strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml")) {

--- a/pkg/eval/helm.go
+++ b/pkg/eval/helm.go
@@ -25,9 +25,16 @@ func evalHelmChart(s spec.Spec) ([]*yaml.RNode, error) {
 		return nil, err
 	}
 
+	helmArgs := s.Helm
+	if helmArgs == nil {
+		helmArgs = &spec.HelmArgs{}
+	}
+
 	// Finally we have an actual chart.
 	// TODO use values, releaseOptions from the spec.
-	values, err := chartutil.ToRenderValues(chart, chartutil.Values{}, chartutil.ReleaseOptions{}, nil)
+	values, err := chartutil.ToRenderValues(chart, chartutil.Values(helmArgs.Values), chartutil.ReleaseOptions{
+		Name: helmArgs.Release.Name,
+	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not create values for chart templates: %w", err)
 	}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -10,6 +10,9 @@ type Spec struct {
 	Source string `json:"source"`
 	// the version of the source that's to be evaluated
 	Version string `json:"version"`
+
+	// kind-specific bits
+	Helm *HelmArgs `json:"helm,omitempty"`
 }
 
 type Kind string
@@ -23,4 +26,11 @@ const (
 func (s *Spec) Init(k Kind) {
 	s.APIVersion = APIVersion
 	s.Kind = k
+}
+
+type HelmArgs struct {
+	Values  map[string]interface{} `json:"values"`
+	Release struct {
+		Name string `json:"name"`
+	} `json:"release"`
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -1,5 +1,7 @@
 package spec
 
+const APIVersion = "spresm.squaremo.dev/v1alpha1"
+
 type Spec struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       Kind   `json:"kind"`
@@ -17,3 +19,8 @@ const (
 	ChartKind Kind = "HelmChart"
 	GitKind   Kind = "Git"
 )
+
+func (s *Spec) Init(k Kind) {
+	s.APIVersion = APIVersion
+	s.Kind = k
+}


### PR DESCRIPTION
This adds a command for importing (that is, specifying then evaluating into files) a Helm chart.

    spresm import helm flux-system --chart https://charts.fluxcd.io/flux --version 1.5

will get the chart, ask you to edit the values, then write the spec file and generated files into `flux-system/`. From there you can update it after editing the spec file with `spresm update flux-system`, and/or modify the generated files locally.
