### PR TITLE
Give update an --edit flag

### DIFF
--- a/cmd/spresm/main.go
+++ b/cmd/spresm/main.go
@@ -18,14 +18,6 @@ func main() {
 	root.Execute()
 }
 
-func newUpdateCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "update <dir>",
-		Short: `update the package in <dir> according to its spec file`,
-		RunE:  updateCmd,
-	}
-}
-
 func newEvalCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "eval <dir>",

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -281,3 +281,44 @@ spec:
 `
 	testMerge(t, local, base, updated, merged)
 }
+
+// A change in a list item in newly generated resources is kept
+func TestListItem(t *testing.T) {
+	base := `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: hello
+        image: helloworld:1.0
+        args:
+        - --greeting=hello
+`
+	local := `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: hello
+        image: helloworld:1.2
+        args:
+        - --greeting=hello
+`
+	updated := `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: hello
+        image: helloworld:1.2
+        args:
+        - --greeting=tena koe
+`
+	testMerge(t, updated, base, local, updated)
+}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -28,6 +28,15 @@ func (s *Spec) Init(k Kind) {
 	s.Kind = k
 }
 
+func (s *Spec) Config() interface{} {
+	switch s.Kind {
+	case ChartKind:
+		return s.Helm
+	default: // TODO: other kinds
+		return nil
+	}
+}
+
 type HelmArgs struct {
 	Values  map[string]interface{} `json:"values"`
 	Release struct {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -50,5 +50,5 @@ type HelmArgs struct {
 }
 
 type ImageArgs struct {
-	FunctionConfig interface{} `json:"functionConfig"`
+	FunctionConfig interface{} `json:"functionConfig" yaml:"functionConfig"`
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -2,17 +2,20 @@ package spec
 
 const APIVersion = "spresm.squaremo.dev/v1alpha1"
 
+// Spec is a specification for generating configuration.
 type Spec struct {
-	APIVersion string `json:"apiVersion"`
-	Kind       Kind   `json:"kind"`
+	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind   `json:"kind" yaml:"kind"`
 
 	// the upstream source; might be an image repository, or a git URL
-	Source string `json:"source"`
+	Source string `json:"source",yaml:"source"`
 	// the version of the source that's to be evaluated
-	Version string `json:"version"`
+	Version string `json:"version" yaml:"version"`
 
 	// kind-specific bits
-	Helm *HelmArgs `json:"helm,omitempty"`
+	// +optional
+	Helm  *HelmArgs  `json:"helm,omitempty" yaml:"helm,omitempty"`
+	Image *ImageArgs `json:"image,omitempty" yaml:"image,omitempty"`
 }
 
 type Kind string
@@ -32,6 +35,8 @@ func (s *Spec) Config() interface{} {
 	switch s.Kind {
 	case ChartKind:
 		return s.Helm
+	case ImageKind:
+		return s.Image
 	default: // TODO: other kinds
 		return nil
 	}
@@ -42,4 +47,8 @@ type HelmArgs struct {
 	Release struct {
 		Name string `json:"name"`
 	} `json:"release"`
+}
+
+type ImageArgs struct {
+	FunctionConfig interface{} `json:"functionConfig"`
 }


### PR DESCRIPTION
This gives update an --edit flag, which presents the configuration
part of the config to the user for editing. For Helm, this means both
the values and the release options (also now included when importing).