### PR TITLE
Flag to supply namespace

### DIFF
--- a/cmd/spresm/import_helm.go
+++ b/cmd/spresm/import_helm.go
@@ -24,12 +24,13 @@ func newImportHelmChartCommand() *cobra.Command {
 }
 
 type importHelmChartFlags struct {
-	chartURL, version string
+	chartURL, version, namespace string
 }
 
 func (flags *importHelmChartFlags) init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&flags.chartURL, "chart", "", "URL for chart, including the repository; e.g., https://charts.fluxcd.io/flux")
 	cmd.Flags().StringVar(&flags.version, "version", "", "version of chart to use")
+	cmd.Flags().StringVar(&flags.namespace, "namespace", "default", "namespace to deploy chart to")
 }
 
 func (flags *importHelmChartFlags) run(cmd *cobra.Command, args []string) error {
@@ -60,6 +61,7 @@ func (flags *importHelmChartFlags) run(cmd *cobra.Command, args []string) error 
 
 	s.Helm = &spec.HelmArgs{Values: chart.Values}
 	s.Helm.Release.Name = filepath.Base(dir)
+	s.Helm.Release.Namespace = flags.namespace
 
 	valuesReader, err := editConfig(s.Helm)
 	if err != nil {

--- a/pkg/eval/helm.go
+++ b/pkg/eval/helm.go
@@ -33,7 +33,8 @@ func evalHelmChart(s spec.Spec) ([]*yaml.RNode, error) {
 	// Finally we have an actual chart.
 	// TODO use values, releaseOptions from the spec.
 	values, err := chartutil.ToRenderValues(chart, chartutil.Values(helmArgs.Values), chartutil.ReleaseOptions{
-		Name: helmArgs.Release.Name,
+		Name:      helmArgs.Release.Name,
+		Namespace: helmArgs.Release.Namespace,
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not create values for chart templates: %w", err)

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -43,11 +43,11 @@ func (s *Spec) Config() interface{} {
 }
 
 type HelmArgs struct {
-	Values  map[string]interface{} `json:"values"`
 	Release struct {
 		Name      string `json:"name"`
 		Namespace string `json:"namespace"`
 	} `json:"release"`
+	Values map[string]interface{} `json:"values"`
 }
 
 type ImageArgs struct {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -45,7 +45,8 @@ func (s *Spec) Config() interface{} {
 type HelmArgs struct {
 	Values  map[string]interface{} `json:"values"`
 	Release struct {
-		Name string `json:"name"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
 	} `json:"release"`
 }
 


### PR DESCRIPTION
Charts typically expect a namespace value. This adds a flag

    spresm import helm --namespace=ns

and wires it through to the release options given when rendering the
chart.